### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_search/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_search/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_search/actions/workflows/test-and-release.yml)
 
-# Description
+# Search Within Pads for Etherpad
 A very crude search function
 
 DO NOT USE THIS IN PRODUCTION


### PR DESCRIPTION
Replace the placeholder `ep_search` heading in README.md with "Search Within Pads for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.